### PR TITLE
BOSA21Q1-933 Anderlecht : video doesn't appear in font end

### DIFF
--- a/lib/extends/decidim-core/app/scrubbers/decidim/user_input_scrubber.rb
+++ b/lib/extends/decidim-core/app/scrubbers/decidim/user_input_scrubber.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module UserInputScrubberExtend
+  extend ActiveSupport::Concern
+
+  included do
+
+    private
+
+    def custom_allowed_attributes
+      Loofah::HTML5::SafeList::ALLOWED_ATTRIBUTES + %w(frameborder allowfullscreen) - %w(onerror)
+    end
+
+    def custom_allowed_tags
+      Loofah::HTML5::SafeList::ALLOWED_ELEMENTS_WITH_LIBXML2 + %w(comment iframe)
+    end
+
+  end
+end
+
+Decidim::UserInputScrubber.send(:include, UserInputScrubberExtend)


### PR DESCRIPTION
Corresponding issue reported to decidim: https://github.com/decidim/decidim/issues/9927
While we're waiting for decidim to check the issue and answer the question about the correct way to fix, let's fix that locally, as Anderlecht is going to became public soon on new platform and they need to display videos properly on the pages.