### PR TITLE
BOSA21Q1-937 Fix participatory processes counter shows wrong amount of processes.

### DIFF
--- a/lib/extends/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters_cell.rb
+++ b/lib/extends/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters_cell.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module ParticipatoryProcessesProcessFiltersCellExtend
+  extend ActiveSupport::Concern
+
+  included do
+
+    def filtered_processes(date_filter, filter_with_type: true)
+      query = Decidim::ParticipatoryProcess.ransack(
+        {
+          with_date: date_filter,
+          with_scope: get_filter(:with_scope),
+          with_area: get_filter(:with_area),
+          with_type: filter_with_type ? get_filter(:with_type) : nil,
+          decidim_organization_id_eq: current_organization.id
+        }
+      ).result
+
+      query.published.visible_for(current_user)
+    end
+
+  end
+end
+
+Decidim::ParticipatoryProcesses::ProcessFiltersCell.send(:include, ParticipatoryProcessesProcessFiltersCellExtend)


### PR DESCRIPTION
Fix participatory processes filters doesn't consider current organization.
After switching to Ransack the `organization` filter became broken, it was ignored by ransack.
Original code for the reference: https://github.com/decidim/decidim/blob/v0.27.0/decidim-participatory_processes/app/cells/decidim/participatory_processes/process_filters_cell.rb#L40-L49

While the issue is in decidim it's not proposed as a fix for them because this component is likely to change in the redesign, so the fix won't be accepted as it is for old design.