### PR TITLE
BOSA21Q1-621 GDPR - Delete user account when not used after a certain period of time (data retention)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem "wicked_pdf", "~> 2.1"
 gem "dotenv-rails"
 
 ## Sidekiq
-gem "sidekiq"
+gem "sidekiq", "<7"
 gem "sidekiq-scheduler"
 
 ## Debugging and Monitoring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,7 +340,7 @@ GEM
     coffee-script-source (1.12.2)
     commonmarker (0.23.6)
     concurrent-ruby (1.1.10)
-    connection_pool (2.2.5)
+    connection_pool (2.3.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -757,10 +757,10 @@ GEM
       sentry-ruby (~> 5.4.2)
       sidekiq (>= 3.0)
     seven_zip_ruby (1.3.0)
-    sidekiq (6.5.5)
-      connection_pool (>= 2.2.2)
+    sidekiq (6.5.8)
+      connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
-      redis (>= 4.5.0)
+      redis (>= 4.5.0, < 5)
     sidekiq-scheduler (4.0.2)
       redis (>= 4.2.0)
       rufus-scheduler (~> 3.2)
@@ -879,7 +879,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   sentry-sidekiq
-  sidekiq
+  sidekiq (< 7)
   sidekiq-scheduler
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)

--- a/Readme-customizations.md
+++ b/Readme-customizations.md
@@ -41,6 +41,8 @@ config.maximum_attempts = 5
 ### Additional functionalities
 - App level basic auth - [commit](https://github.com/belighted/bosa-cities-new/commit/0008810e75a0ef972e773b4745b81a12ec50468e)
 - Org level basic auth - [PR](https://github.com/belighted/bosa-cities-new/pull/10)
+- Automatically delete user account when not used for a certain period of time (data retention) - [PR](https://github.com/belighted/bosa-cities-new/pull/15)
+
 
 ### Bugfixes
 ###### Temporary fixes (to remove after it is fixed in decidim)

--- a/app/events/decidim/users/user_auto_deleted_event.rb
+++ b/app/events/decidim/users/user_auto_deleted_event.rb
@@ -1,0 +1,15 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Users
+    class UserAutoDeletedEvent < Decidim::Events::SimpleEvent
+      def resource_path
+        ""
+      end
+
+      def resource_url
+        ""
+      end
+    end
+  end
+end

--- a/app/events/decidim/users/user_marked_for_auto_deletion_event.rb
+++ b/app/events/decidim/users/user_marked_for_auto_deletion_event.rb
@@ -1,0 +1,25 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Users
+    class UserMarkedForAutoDeletionEvent < Decidim::Events::SimpleEvent
+      i18n_attributes :date
+
+      def resource_path
+        ""
+      end
+
+      def resource_url
+        ""
+      end
+
+      def date
+        extra[:date]
+      end
+
+      def sign_in_url
+        extra[:sign_in_url]
+      end
+    end
+  end
+end

--- a/app/jobs/decidim/users_auto_deletion_job.rb
+++ b/app/jobs/decidim/users_auto_deletion_job.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Decidim
+  class UsersAutoDeletionJob < ApplicationJob
+    queue_as :default
+
+    include FormFactory
+
+    attr_reader :settings
+
+    def perform(organization)
+      @organization = organization
+      @settings = (organization.users_auto_deletion_settings || {}).with_indifferent_access
+
+      return unless @settings[:enabled]
+
+      delete_marked_users
+      mark_users_for_deletion
+    end
+
+    private
+
+    def mark_users_for_deletion
+      mark_users_scope.find_in_batches(batch_size: 100) do |users|
+        users.each do |user|
+          # rubocop:disable Rails/SkipsModelValidations
+          user.update_column(:marked_for_auto_deletion_at, Time.zone.today)
+          # rubocop:enable Rails/SkipsModelValidations
+
+          next unless @settings[:send_email_on_mark_for_deletion]
+
+          Decidim::NotificationMailer.event_received(
+            "decidim.events.users.user_marked_for_auto_deletion", # event
+            Decidim::Users::UserMarkedForAutoDeletionEvent.name, # event_class_name
+            user, # resource
+            user, # user
+            "affected_user", # user_role
+            {
+              date: I18n.l(Time.zone.today + delete_marked_after, format: :default),
+              sign_in_url: Decidim::Core::Engine.routes.url_helpers.user_session_url(host: @organization.host)
+            } # extra
+          ).deliver_later
+        end
+      end
+    end
+
+    def delete_marked_users
+      @organization.users.not_deleted.where("marked_for_auto_deletion_at <= ?", Time.zone.today - delete_marked_after).find_in_batches(batch_size: 100).each do |users|
+        users.each do |user|
+          next if cleared_mark_for_deletion?(user)
+
+          f = form(Decidim::DeleteAccountForm).from_params({ delete_reason: "Automatically deleted due to inactivity" })
+          Decidim::DestroyAccount.call(user, f) do
+            on(:ok) do
+              next unless settings[:send_email_on_deletion]
+
+              Decidim::NotificationMailer.event_received(
+                "decidim.events.users.user_auto_deleted", # event
+                Decidim::Users::UserAutoDeletedEvent.name, # event_class_name
+                user, # resource
+                user, # user
+                "affected_user", # user_role
+                {} # extra
+              ).deliver_later
+            end
+          end
+        end
+      end
+    end
+
+    def cleared_mark_for_deletion?(user)
+      if (user.admin? && !delete_admin_users?) ||
+         (user.last_sign_in_at && user.last_sign_in_at >= user.marked_for_auto_deletion_at) ||
+         (user.last_sign_in_at && user.last_sign_in_at >= Time.zone.today - mark_for_deletion_after)
+        # rubocop:disable Rails/SkipsModelValidations
+        user.update_column(:marked_for_auto_deletion_at, nil)
+        # rubocop:enable Rails/SkipsModelValidations
+      end
+    end
+
+    def mark_users_scope
+      scope = @organization.users.not_deleted
+      scope = delete_admin_users? ? scope : scope.where(admin: false)
+      scope = scope.where("last_sign_in_at::date < ?", Time.zone.today - mark_for_deletion_after)
+      scope.where(marked_for_auto_deletion_at: nil)
+    end
+
+    def delete_admin_users?
+      @settings[:delete_admin_users]
+    end
+
+    def mark_for_deletion_after
+      @settings[:mark_for_deletion_after].to_i.send(@settings[:mark_for_deletion_after_unit])
+    end
+
+    def delete_marked_after
+      @settings[:delete_marked_after].to_i.send(@settings[:delete_marked_after_unit])
+    end
+  end
+end

--- a/app/jobs/delete_inactive_users_job.rb
+++ b/app/jobs/delete_inactive_users_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DeleteInactiveUsersJob < ApplicationJob
+  def perform
+    BosaCitiesNew::Application.load_tasks if Rake::Task.tasks.empty?
+    Rake::Task["decidim:users_auto_deletion"].reenable
+    Rake::Task["decidim:users_auto_deletion"].invoke
+  end
+end

--- a/app/views/decidim/system/organizations/_advanced_settings.html.erb
+++ b/app/views/decidim/system/organizations/_advanced_settings.html.erb
@@ -6,6 +6,7 @@
 <div class="collapsible hide">
   <%= render partial: "basic_auth_settings", locals: { f: f } %>
   <%= render partial: "smtp_settings", locals: { f: f } %>
+  <%= render partial: "users_auto_deletion_settings", locals: { f: f } %>
   <%= render partial: "omniauth_settings", locals: { f: f } %>
   <%= render partial: "file_upload_settings", locals: { f: f } %>
 </div>

--- a/app/views/decidim/system/organizations/_users_auto_deletion_settings.html.erb
+++ b/app/views/decidim/system/organizations/_users_auto_deletion_settings.html.erb
@@ -1,0 +1,36 @@
+<div class="fieldset">
+  <h4><%= t("decidim.system.models.organization.fields.users_auto_deletion_settings") %></h4>
+  <%= f.fields_for :users_auto_deletion_settings do %>
+    <div class="field">
+      <%= f.check_box :enabled %>
+      <p class="help-text"><%= t(".instructions.enabled") %></p>
+    </div>
+    <fieldset class="fieldset">
+      <legend><%= t(".fieldsets.mark_for_deletion_after") %></legend>
+      <p class="help-text"><%= t(".instructions.mark_for_deletion_after") %></p>
+      <%= f.number_field :mark_for_deletion_after, { label: t(".fields.mark_for_deletion_after") } %>
+      <%= f.select :mark_for_deletion_after_unit,
+                   Decidim::System::UpdateOrganizationForm::USERS_AUTO_DELETION_UNITS.map { |unit| [t(".units.#{unit}"), unit] },
+                   { include_blank: false, label: false },
+                   { multiple: false } %>
+      <div class="field">
+        <%= f.check_box :send_email_on_mark_for_deletion %>
+      </div>
+    </fieldset>
+    <fieldset class="fieldset">
+      <legend><%= t(".fieldsets.delete_marked_after") %></legend>
+      <p class="help-text"><%= t(".instructions.delete_marked_after") %></p>
+      <%= f.number_field :delete_marked_after, { label: t(".fields.delete_marked_after") } %>
+      <%= f.select :delete_marked_after_unit,
+                   Decidim::System::UpdateOrganizationForm::USERS_AUTO_DELETION_UNITS.map { |unit| [t(".units.#{unit}"), unit] },
+                   { include_blank: false, label: false },
+                   { multiple: false } %>
+      <div class="field">
+        <%= f.check_box :delete_admin_users %>
+      </div>
+      <div class="field">
+        <%= f.check_box :send_email_on_deletion %>
+      </div>
+    </fieldset>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,37 +1,41 @@
-# Files in the config/locales directory are used for internationalization
-# and are automatically loaded by Rails. If you want to use locales other
-# than English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t 'hello'
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t('hello') %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# The following keys must be escaped otherwise they will not be retrieved by
-# the default I18n backend:
-#
-# true, false, on, off, yes, no
-#
-# Instead, surround them with single quotes.
-#
-# en:
-#   'true': 'foo'
-#
-# To learn more, please read the Rails Internationalization guide
-# available at https://guides.rubyonrails.org/i18n.html.
-
 en:
   decidim:
     authorization_handlers:
       participant_impersonation_handler:
         name: Participants impersonations authorization
         explanation: Auth handler for participants impersonations
+
+    events:
+      users:
+        user_marked_for_auto_deletion:
+          email_intro: Your account will be deleted on %{date}.
+          email_outro: Please log in again to prevent automatic deletion of your account - %{sign_in_url}.
+          email_subject: Your account will be deleted on %{date}.
+        user_auto_deleted:
+          email_intro: Your account has been deleted.
+          email_outro: Your account has been deleted.
+          email_subject: Your account has been deleted.
+
+    system:
+      models:
+        organization:
+          fields:
+            users_auto_deletion_settings: Users auto deletion settings
+      organizations:
+        users_auto_deletion_settings:
+          fieldsets:
+            enabled: Enable auto deletion of inactive users
+            mark_for_deletion_after: Step 1. Mark users for deletion
+            delete_marked_after: Step 2. Delete marked users
+          fields:
+            mark_for_deletion_after: Mark for deletion after
+            delete_marked_after: Delete marked users after
+          instructions:
+            enabled: Configure automatic users deletion.
+            mark_for_deletion_after: Mark users for automatic deletion after X days/monts of inactivity (after last sign in date)
+            delete_marked_after: Delete users X days/monts after they were marked for deletion if they are still inactive
+          units:
+            days: Days
+            weeks: Weeks
+            months: Months
+            years: Years

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,12 @@
+fr:
+  decidim:
+    events:
+      users:
+        user_marked_for_auto_deletion:
+          email_intro: Votre compte sera supprimé le %{date}.
+          email_outro: Veuillez vous reconnecter pour empêcher la suppression automatique de votre compte - %{sign_in_url}.
+          email_subject: Votre compte sera supprimé le %{date}.
+        user_auto_deleted:
+          email_intro: Votre compte a été supprimé.
+          email_outro: Votre compte a été supprimé.
+          email_subject: Votre compte a été supprimé.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,0 +1,12 @@
+nl:
+  decidim:
+    events:
+      users:
+        user_marked_for_auto_deletion:
+          email_intro: Uw account wordt verwijderd op %{date}.
+          email_outro: Log opnieuw in om te voorkomen dat uw account automatisch wordt verwijderd - %{sign_in_url}.
+          email_subject: Uw account wordt verwijderd op %{date}.
+        user_auto_deleted:
+          email_intro: Uw account is verwijderd.
+          email_outro: Uw account is verwijderd.
+          email_subject: Uw account is verwijderd.

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -17,3 +17,6 @@
   PreloadOpenData:
     cron: '0 17 * * *'
     class: PreloadOpenDataJob
+  DeleteInactiveUsers:
+    cron: '0 1 * * *'
+    class: DeleteInactiveUsersJob

--- a/db/migrate/20221129160155_add_users_auto_deletion_settings_to_decidim_organizations.rb
+++ b/db/migrate/20221129160155_add_users_auto_deletion_settings_to_decidim_organizations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUsersAutoDeletionSettingsToDecidimOrganizations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_organizations, :users_auto_deletion_settings, :jsonb
+  end
+end

--- a/db/migrate/20221129160156_add_auto_delete_on_date_to_decidim_users.rb
+++ b/db/migrate/20221129160156_add_auto_delete_on_date_to_decidim_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAutoDeleteOnDateToDecidimUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :decidim_users, :marked_for_auto_deletion_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_20_123232) do
+ActiveRecord::Schema.define(version: 2022_11_29_160156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -995,6 +995,7 @@ ActiveRecord::Schema.define(version: 2022_10_20_123232) do
     t.boolean "enable_participatory_space_filters", default: true
     t.string "basic_auth_username"
     t.string "basic_auth_password"
+    t.jsonb "users_auto_deletion_settings"
     t.index ["host"], name: "index_decidim_organizations_on_host", unique: true
     t.index ["name"], name: "index_decidim_organizations_on_name", unique: true
   end
@@ -1577,6 +1578,7 @@ ActiveRecord::Schema.define(version: 2022_10_20_123232) do
     t.datetime "digest_sent_at"
     t.datetime "password_updated_at"
     t.string "previous_passwords", default: [], array: true
+    t.date "marked_for_auto_deletion_at"
     t.index ["confirmation_token"], name: "index_decidim_users_on_confirmation_token", unique: true
     t.index ["decidim_organization_id"], name: "index_decidim_users_on_decidim_organization_id"
     t.index ["email", "decidim_organization_id"], name: "index_decidim_users_on_email_and_decidim_organization_id", unique: true, where: "((deleted_at IS NULL) AND (managed = false) AND ((type)::text = 'Decidim::User'::text))"

--- a/lib/extends/decidim-system/app/commands/decidim/system/update_organization.rb
+++ b/lib/extends/decidim-system/app/commands/decidim/system/update_organization.rb
@@ -20,6 +20,7 @@ module SystemUpdateOrganizationExtend
       organization.omniauth_settings = form.encrypted_omniauth_settings
       organization.smtp_settings = form.encrypted_smtp_settings
       organization.file_upload_settings = form.file_upload_settings.final
+      organization.users_auto_deletion_settings = form.users_auto_deletion_settings
 
       organization.save!
     end

--- a/lib/extends/decidim-system/app/forms/decidim/system/update_organization_form.rb
+++ b/lib/extends/decidim-system/app/forms/decidim/system/update_organization_form.rb
@@ -10,6 +10,18 @@ module UpdateOrganizationFormExtend
 
     attribute :basic_auth_username, String
     attribute :basic_auth_password, String
+
+    USERS_AUTO_DELETION_UNITS = %w(days weeks months years).freeze
+    jsonb_attribute :users_auto_deletion_settings, [
+      [:enabled, Decidim::AttributeObject::TypeMap::Boolean],
+      [:mark_for_deletion_after, Integer],
+      [:mark_for_deletion_after_unit, String],
+      [:delete_marked_after, Integer],
+      [:delete_marked_after_unit, String],
+      [:delete_admin_users, Decidim::AttributeObject::TypeMap::Boolean],
+      [:send_email_on_mark_for_deletion, Decidim::AttributeObject::TypeMap::Boolean],
+      [:send_email_on_deletion, Decidim::AttributeObject::TypeMap::Boolean]
+    ]
   end
 end
 

--- a/lib/tasks/decidim_users_auto_deletion_tasks.rake
+++ b/lib/tasks/decidim_users_auto_deletion_tasks.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+namespace :decidim do
+  desc "Generates tasks for each organization."
+  task users_auto_deletion: :environment do
+    Decidim::Organization.find_each do |organization|
+      Decidim::UsersAutoDeletionJob.perform_later(organization)
+    end
+  end
+end

--- a/spec/decidim-core/jobs/decidim/users_auto_deletion_job_spec.rb
+++ b/spec/decidim-core/jobs/decidim/users_auto_deletion_job_spec.rb
@@ -1,0 +1,275 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::UsersAutoDeletionJob do
+  subject { described_class }
+
+  include Decidim::FormFactory
+
+  let(:organization) { create(:organization, users_auto_deletion_settings: users_auto_deletion_settings) }
+  let(:users_auto_deletion_settings) do
+    {
+      enabled: enabled,
+      mark_for_deletion_after: mark_for_deletion_after,
+      mark_for_deletion_after_unit: mark_for_deletion_after_unit,
+      delete_marked_after: delete_marked_after,
+      delete_marked_after_unit: delete_marked_after_unit,
+      delete_admin_users: delete_admin_users,
+      send_email_on_mark_for_deletion: send_email_on_mark_for_deletion,
+      send_email_on_deletion: send_email_on_deletion
+    }
+  end
+  let(:enabled) { true }
+  let(:mark_for_deletion_after) { 11 }
+  let(:mark_for_deletion_after_unit) { "months" }
+  let(:delete_marked_after) { 1 }
+  let(:delete_marked_after_unit) { "months" }
+  let(:delete_admin_users) { true }
+  let(:send_email_on_mark_for_deletion) { true }
+  let(:send_email_on_deletion) { true }
+
+  let(:mailer) { double(deliver_later: true) }
+
+  before do
+    clear_enqueued_jobs
+    allow(Decidim::NotificationMailer).to receive(:event_received).and_return(mailer)
+  end
+
+  describe "queue" do
+    it "is queued to events" do
+      expect(subject.queue_name).to eq "default"
+    end
+  end
+
+  describe "perform" do
+    let(:mark_date) { Time.zone.today - mark_for_deletion_after.send(mark_for_deletion_after_unit) }
+    let(:delete_date) { Time.zone.today - mark_date - delete_marked_after.send(delete_marked_after_unit) }
+    let!(:active_user) { create(:user, :confirmed, organization: organization, last_sign_in_at: mark_date) }
+
+    context "when auto deletion is disabled" do
+      let(:enabled) { false }
+      let!(:inactive_user) { create(:user, :confirmed, organization: organization, last_sign_in_at: mark_date - 1.day) }
+
+      it "doesn't do anything" do
+        expect(Decidim::NotificationMailer).not_to receive(:event_received)
+        expect(Decidim::DestroyAccount).not_to receive(:call)
+        subject.perform_now(organization)
+      end
+    end
+
+    context "when mark users for deletion" do
+      let!(:inactive_user) { create(:user, :confirmed, organization: organization, last_sign_in_at: mark_date - 1.day) }
+
+      it "marks inactive user" do
+        allow(Decidim::NotificationMailer).to receive(:event_received).with(*mark_event_mailer_params_for(inactive_user)).and_return(mailer)
+        subject.perform_now(organization)
+        expect(Decidim::NotificationMailer).to have_received(:event_received).exactly(1).time
+        expect(inactive_user.reload.marked_for_auto_deletion_at).not_to be_nil
+      end
+
+      it "doesn't mark active user for deletion" do
+        subject.perform_now(organization)
+        expect(inactive_user.reload.marked_for_auto_deletion_at).not_to be_nil
+        expect(active_user.reload.marked_for_auto_deletion_at).to be_nil
+      end
+
+      context "when there is another inactive user" do
+        context "and it is not marked for deletion" do
+          let!(:another_inactive_user) { create(:user, :confirmed, organization: organization, last_sign_in_at: mark_date - 1.day) }
+
+          it "marks both users" do
+            allow(Decidim::NotificationMailer).to receive(:event_received).with(*mark_event_mailer_params_for(inactive_user)).and_return(mailer)
+            allow(Decidim::NotificationMailer).to receive(:event_received).with(*mark_event_mailer_params_for(another_inactive_user)).and_return(mailer)
+            subject.perform_now(organization)
+            expect(Decidim::NotificationMailer).to have_received(:event_received).exactly(2).times
+            expect(inactive_user.reload.marked_for_auto_deletion_at).not_to be_nil
+            expect(another_inactive_user.reload.marked_for_auto_deletion_at).not_to be_nil
+          end
+        end
+
+        context "and it is already marked for deletion" do
+          let!(:inactive_marked_user) { create(:user, :confirmed, organization: organization, last_sign_in_at: mark_date - 1.day, marked_for_auto_deletion_at: Time.zone.today) }
+
+          it "marks only not marked user" do
+            allow(Decidim::NotificationMailer).to receive(:event_received).with(*mark_event_mailer_params_for(inactive_user)).and_return(mailer)
+            subject.perform_now(organization)
+            expect(Decidim::NotificationMailer).to have_received(:event_received).exactly(1).time
+            expect(inactive_user.reload.marked_for_auto_deletion_at).not_to be_nil
+          end
+        end
+      end
+
+      context "when configured not to send email on mark for deletion" do
+        let(:send_email_on_mark_for_deletion) { false }
+
+        it "marks inactive user and doesn't send an email" do
+          expect(Decidim::NotificationMailer).not_to receive(:event_received)
+          subject.perform_now(organization)
+          expect(inactive_user.reload.marked_for_auto_deletion_at).not_to be_nil
+        end
+      end
+
+      context "when inactive user is admin" do
+        let!(:inactive_user) { create(:user, :confirmed, :admin, organization: organization, last_sign_in_at: mark_date - 1.day) }
+
+        it "marks inactive admin user" do
+          allow(Decidim::NotificationMailer).to receive(:event_received).with(*mark_event_mailer_params_for(inactive_user)).and_return(mailer)
+          subject.perform_now(organization)
+          expect(Decidim::NotificationMailer).to have_received(:event_received).exactly(1).time
+          expect(inactive_user.reload.marked_for_auto_deletion_at).not_to be_nil
+        end
+
+        context "and configured not to delete admin users" do
+          let(:delete_admin_users) { false }
+
+          it "doesn't mark user for deletion" do
+            expect(Decidim::NotificationMailer).not_to receive(:event_received)
+            subject.perform_now(organization)
+            expect(inactive_user.reload.marked_for_auto_deletion_at).to be_nil
+          end
+        end
+      end
+
+      context "and there is another organization" do
+        let!(:another_organization) { create(:organization) }
+        let!(:another_inactive_user) { create(:user, :confirmed, organization: another_organization, last_sign_in_at: mark_date - 1.day) }
+
+        it "marks inactive user of current organization only" do
+          allow(Decidim::NotificationMailer).to receive(:event_received).with(*mark_event_mailer_params_for(inactive_user)).and_return(mailer)
+          subject.perform_now(organization)
+          expect(Decidim::NotificationMailer).to have_received(:event_received).exactly(1).time
+          expect(inactive_user.reload.marked_for_auto_deletion_at).not_to be_nil
+        end
+
+        it "doesn't affect user from another organization" do
+          subject.perform_now(organization)
+          expect(inactive_user.reload.marked_for_auto_deletion_at).not_to be_nil
+          expect(another_inactive_user.reload.marked_for_auto_deletion_at).to be_nil
+        end
+      end
+    end
+
+    context "when delete marked users" do
+      context "and user remains inactive after it is marked for deletion" do
+        let!(:marked_inactive_user) { create(:user, :confirmed, organization: organization, last_sign_in_at: delete_date - 1.day, marked_for_auto_deletion_at: mark_date) }
+
+        it "deletes user" do
+          allow(Decidim::NotificationMailer).to receive(:event_received).with(*delete_event_mailer_params_for(marked_inactive_user)).and_return(mailer)
+          subject.perform_now(organization)
+          expect(Decidim::NotificationMailer).to have_received(:event_received).exactly(1).times
+          expect(marked_inactive_user.reload.deleted?).to be true
+          expect(marked_inactive_user.reload.delete_reason).to eq("Automatically deleted due to inactivity")
+        end
+      end
+
+      context "and user becomes active after it is marked for deletion" do
+        let!(:marked_active_user) { create(:user, :confirmed, organization: organization, last_sign_in_at: mark_date, marked_for_auto_deletion_at: mark_date) }
+
+        it "doesn't delete user" do
+          expect(Decidim::NotificationMailer).not_to receive(:event_received)
+          subject.perform_now(organization)
+          expect(marked_active_user.reload.deleted?).to be false
+          expect(marked_active_user.reload.delete_reason).to be_nil
+          expect(marked_active_user.reload.marked_for_auto_deletion_at).to be_nil
+        end
+      end
+
+      context "when configured not to send email on deletion" do
+        let!(:marked_inactive_user) { create(:user, :confirmed, organization: organization, last_sign_in_at: delete_date - 1.day, marked_for_auto_deletion_at: mark_date) }
+        let(:send_email_on_deletion) { false }
+
+        it "deletes user and doesn't send an email" do
+          expect(Decidim::NotificationMailer).not_to receive(:event_received)
+          subject.perform_now(organization)
+          expect(marked_inactive_user.reload.deleted?).to be true
+          expect(marked_inactive_user.reload.delete_reason).to eq("Automatically deleted due to inactivity")
+        end
+      end
+
+      context "and user is already deleted" do
+        let(:delete_reason) { "Another delete reason." }
+        let!(:deleted_user) { create(:user, :confirmed, :deleted, organization: organization, last_sign_in_at: delete_date - 1.day, marked_for_auto_deletion_at: mark_date, delete_reason: delete_reason) }
+
+        it "ignores deleted user" do
+          expect(Decidim::NotificationMailer).not_to receive(:event_received)
+          subject.perform_now(organization)
+          expect(deleted_user.reload.deleted?).to be true
+          expect(deleted_user.reload.delete_reason).to eq(delete_reason)
+        end
+      end
+
+      context "when marked inactive user is admin" do
+        let!(:marked_admin_user) { create(:user, :confirmed, :admin, organization: organization, last_sign_in_at: delete_date - 1.day, marked_for_auto_deletion_at: mark_date) }
+
+        it "deletes admin user" do
+          allow(Decidim::NotificationMailer).to receive(:event_received).with(*delete_event_mailer_params_for(marked_admin_user)).and_return(mailer)
+          subject.perform_now(organization)
+          expect(Decidim::NotificationMailer).to have_received(:event_received).exactly(1).times
+          expect(marked_admin_user.reload.deleted?).to be true
+          expect(marked_admin_user.reload.delete_reason).to eq("Automatically deleted due to inactivity")
+        end
+
+        context "and configured not to delete admin users" do
+          let(:delete_admin_users) { false }
+
+          it "doesn't delete admin user" do
+            expect(Decidim::NotificationMailer).not_to receive(:event_received)
+            subject.perform_now(organization)
+            expect(marked_admin_user.reload.deleted?).to be false
+            expect(marked_admin_user.reload.delete_reason).to be_nil
+            expect(marked_admin_user.reload.marked_for_auto_deletion_at).to be_nil
+          end
+        end
+      end
+
+      context "and there is another organization" do
+        let!(:marked_inactive_user) { create(:user, :confirmed, organization: organization, last_sign_in_at: delete_date - 1.day, marked_for_auto_deletion_at: mark_date) }
+        let!(:another_organization) { create(:organization) }
+        let!(:another_marked_inactive_user) { create(:user, :confirmed, organization: another_organization, last_sign_in_at: delete_date - 1.day, marked_for_auto_deletion_at: mark_date) }
+
+        it "deletes user of current organization only" do
+          allow(Decidim::NotificationMailer).to receive(:event_received).with(*delete_event_mailer_params_for(marked_inactive_user)).and_return(mailer)
+          subject.perform_now(organization)
+          expect(Decidim::NotificationMailer).to have_received(:event_received).exactly(1).times
+          expect(marked_inactive_user.reload.deleted?).to be true
+          expect(marked_inactive_user.reload.delete_reason).to eq("Automatically deleted due to inactivity")
+        end
+
+        it "doesn't affect user from another organization" do
+          subject.perform_now(organization)
+          expect(marked_inactive_user.reload.deleted?).to be true
+          expect(marked_inactive_user.reload.delete_reason).to eq("Automatically deleted due to inactivity")
+
+          expect(another_marked_inactive_user.reload.deleted?).to be false
+          expect(another_marked_inactive_user.reload.delete_reason).to be_nil
+        end
+      end
+    end
+  end
+
+  def mark_event_mailer_params_for(user)
+    [
+      "decidim.events.users.user_marked_for_auto_deletion",
+      Decidim::Users::UserMarkedForAutoDeletionEvent.name,
+      user,
+      user,
+      "affected_user",
+      {
+        date: I18n.l(Time.zone.today + delete_marked_after.send(delete_marked_after_unit), format: :default),
+        sign_in_url: Decidim::Core::Engine.routes.url_helpers.user_session_url(host: organization.host)
+      }
+    ]
+  end
+
+  def delete_event_mailer_params_for(user)
+    [
+      "decidim.events.users.user_auto_deleted",
+      Decidim::Users::UserAutoDeletedEvent.name,
+      user,
+      user,
+      "affected_user",
+      {}
+    ]
+  end
+end

--- a/spec/decidim-core/tasks/decidim_users_auto_deletion_spec.rb
+++ b/spec/decidim-core/tasks/decidim_users_auto_deletion_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe "Executing Decidim Users Auto Deletion tasks" do
+  describe "rake decidim:users_auto_deletion", type: :task do
+    let!(:organizations) { create_list(:organization, 2) }
+
+    after { clear_enqueued_jobs }
+
+    context "when executing task" do
+      it "have to be executed without failures" do
+        Rake::Task[:"decidim:users_auto_deletion"].reenable
+        expect { Rake::Task[:"decidim:users_auto_deletion"].invoke }.not_to raise_error
+      end
+
+      it "creates jobs for each organization" do
+        Rake::Task[:"decidim:users_auto_deletion"].reenable
+        expect { Rake::Task[:"decidim:users_auto_deletion"].invoke }.to have_enqueued_job(Decidim::UsersAutoDeletionJob).exactly(Decidim::Organization.count).times
+      end
+    end
+  end
+end

--- a/spec/decidim-system/commands/decidim/system/register_organization_spec.rb
+++ b/spec/decidim-system/commands/decidim/system/register_organization_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Original test should pass normally
+DecidimSpecLoader.run("decidim-system/spec/commands/decidim/system/register_organization_spec.rb")

--- a/spec/decidim-system/commands/decidim/system/update_organization_spec.rb
+++ b/spec/decidim-system/commands/decidim/system/update_organization_spec.rb
@@ -2,7 +2,7 @@
 
 require "spec_helper"
 
-# Original test should also pass normally
+# Original test should pass normally
 DecidimSpecLoader.run("decidim-system/spec/commands/decidim/system/update_organization_spec.rb")
 
 module Decidim
@@ -12,36 +12,74 @@ module Decidim
         let(:form) do
           UpdateOrganizationForm.new(params)
         end
-        let(:organization) { create :organization, name: "My organization" }
+        let(:organization) { create :organization, name: ::Faker::Company.name }
         let(:command) { described_class.new(organization.id, form) }
-        let(:basic_auth_username) { "username" }
-        let(:basic_auth_password) { "password" }
 
-        context "when the form is valid and has basic auth params" do
-          let(:params) do
-            {
-              name: "Gotham City",
-              host: "decide.gotham.gov",
-              users_registration_mode: "existing",
-              file_upload_settings: params_for_uploads(upload_settings),
-              basic_auth_username: basic_auth_username,
-              basic_auth_password: basic_auth_password
-            }
-          end
+        context "when the form is valid" do
           let(:upload_settings) do
             Decidim::OrganizationSettings.default(:upload)
           end
 
-          it "returns a valid response" do
-            expect { command.call }.to broadcast(:ok)
+          context "and has basic auth params" do
+            let(:basic_auth_username) { "username" }
+            let(:basic_auth_password) { "password" }
+            let(:params) do
+              {
+                name: ::Faker::Company.name,
+                host: ::Faker::Internet.domain_name,
+                users_registration_mode: "existing",
+                file_upload_settings: params_for_uploads(upload_settings),
+                basic_auth_username: basic_auth_username,
+                basic_auth_password: basic_auth_password
+              }
+            end
+
+            it "returns a valid response" do
+              expect { command.call }.to broadcast(:ok)
+            end
+
+            it "updates the organization" do
+              expect { command.call }.to change(Organization, :count).by(1)
+              organization = Organization.last
+
+              expect(organization.basic_auth_username).to eq(basic_auth_username)
+              expect(organization.basic_auth_password).to eq(basic_auth_password)
+            end
           end
 
-          it "updates the organization" do
-            expect { command.call }.to change(Organization, :count).by(1)
-            organization = Organization.last
+          context "and has 'users_auto_deletion_settings' params" do
+            let(:params) do
+              {
+                name: ::Faker::Company.name,
+                host: ::Faker::Internet.domain_name,
+                users_registration_mode: "existing",
+                file_upload_settings: params_for_uploads(upload_settings),
+                users_auto_deletion_settings: users_auto_deletion_settings
+              }
+            end
+            let(:users_auto_deletion_settings) do
+              {
+                "enabled" => true,
+                "mark_for_deletion_after" => 11,
+                "mark_for_deletion_after_unit" => "months",
+                "delete_marked_after" => 30,
+                "delete_marked_after_unit" => "days",
+                "delete_admin_users" => true,
+                "send_email_on_mark_for_deletion" => true,
+                "send_email_on_deletion" => true
+              }
+            end
 
-            expect(organization.basic_auth_username).to eq(basic_auth_username)
-            expect(organization.basic_auth_password).to eq(basic_auth_password)
+            it "returns a valid response" do
+              expect { command.call }.to broadcast(:ok)
+            end
+
+            it "updates the organization" do
+              expect { command.call }.to change(Organization, :count).by(1)
+              organization = Organization.last
+
+              expect(organization.users_auto_deletion_settings).to eq(users_auto_deletion_settings)
+            end
           end
         end
 

--- a/spec/decidim-system/forms/decidim/system/update_organization_form_spec.rb
+++ b/spec/decidim-system/forms/decidim/system/update_organization_form_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Original test should pass normally
+DecidimSpecLoader.run("decidim-system/spec/forms/decidim/system/update_organization_form_spec.rb")
+
+module Decidim::System
+  describe UpdateOrganizationForm do
+    subject do
+      described_class.new(
+        name: Faker::Company.name,
+        host: Faker::Internet.domain_name,
+        users_registration_mode: "enabled",
+        **users_auto_deletion_settings
+      )
+    end
+
+    let(:users_auto_deletion_settings) do
+      {
+        "enabled" => true,
+        "mark_for_deletion_after" => 11,
+        "mark_for_deletion_after_unit" => "months",
+        "delete_marked_after" => 30,
+        "delete_marked_after_unit" => "days",
+        "delete_admin_users" => true,
+        "send_email_on_mark_for_deletion" => true,
+        "send_email_on_deletion" => true
+      }
+    end
+
+    context "when everything is OK" do
+      it { is_expected.to be_valid }
+
+      describe "users_auto_deletion_settings" do
+        it "contains attributes as json" do
+          expect(subject.users_auto_deletion_settings).to eq(users_auto_deletion_settings)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
As discussed in the ticket, it doesn't delete users right away, instead the flow represents 2 steps:
- after configured period of time (`mark_for_deletion_after`) inactive users marked for auto deletion, the email sent to user informing his account will be deleted
- after another configured period of time (`delete_marked_after`) it deletes marked user unless user became active or settings has changed to "wider" period of time (normally settings won't change, but could be the case), another email sent to user informing his account has been deleted
