### PR TITLE
BOSA21Q1-830 Fix whitelisted sentry env for production

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -3,7 +3,7 @@
 Sentry.init do |config|
   config.logger = Sentry::Logger.new($stdout)
   config.dsn = ENV.fetch("SENTRY_DSN", nil)
-  config.enabled_environments = %w(bosa-cities-new-production bosa-cities-new-uat)
+  config.enabled_environments = %w(bosa-cities-new bosa-cities-new-uat)
   config.environment = ENV.fetch("SENTRY_CURRENT_ENV", "missing-env")
   config.send_default_pii = true
 end


### PR DESCRIPTION
@simon-lejeune , could you please update the `SENTRY_CURRENT_ENV` var on cities-new UAT from `bosa-cities-new-027-uat` to `bosa-cities-new-uat`, to have clear environment naming. Thank you!