### PR TITLE
BOSA21Q1-621 Users auto deletion

### DIFF
--- a/.github/workflows/ci_core.yml
+++ b/.github/workflows/ci_core.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     branches-ignore:
       - "chore/l10n*"
-    paths:
-      - "*"
 
 env:
   CI: "true"

--- a/.github/workflows/ci_system.yml
+++ b/.github/workflows/ci_system.yml
@@ -9,8 +9,6 @@ on:
   pull_request:
     branches-ignore:
       - "chore/l10n*"
-    paths:
-      - "*"
 
 env:
   CI: "true"

--- a/app/events/decidim/users/user_marked_for_auto_deletion_event.rb
+++ b/app/events/decidim/users/user_marked_for_auto_deletion_event.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Users
     class UserMarkedForAutoDeletionEvent < Decidim::Events::SimpleEvent
-      i18n_attributes :date
+      i18n_attributes :date, :sign_in_url
 
       def resource_path
         ""

--- a/app/views/decidim/system/organizations/_users_auto_deletion_settings.html.erb
+++ b/app/views/decidim/system/organizations/_users_auto_deletion_settings.html.erb
@@ -5,6 +5,9 @@
       <%= f.check_box :enabled %>
       <p class="help-text"><%= t(".instructions.enabled") %></p>
     </div>
+    <div class="field">
+      <%= f.check_box :delete_admin_users %>
+    </div>
     <fieldset class="fieldset">
       <legend><%= t(".fieldsets.mark_for_deletion_after") %></legend>
       <p class="help-text"><%= t(".instructions.mark_for_deletion_after") %></p>
@@ -25,9 +28,6 @@
                    Decidim::System::UpdateOrganizationForm::USERS_AUTO_DELETION_UNITS.map { |unit| [t(".units.#{unit}"), unit] },
                    { include_blank: false, label: false },
                    { multiple: false } %>
-      <div class="field">
-        <%= f.check_box :delete_admin_users %>
-      </div>
       <div class="field">
         <%= f.check_box :send_email_on_deletion %>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,7 @@ en:
       users:
         user_marked_for_auto_deletion:
           email_intro: Your account will be deleted on %{date}.
-          email_outro: Please log in again to prevent automatic deletion of your account - %{sign_in_url}.
+          email_outro: Please log in again to prevent automatic deletion of your account - <a href="%{sign_in_url}">Sign In</a>.
           email_subject: Your account will be deleted on %{date}.
         user_auto_deleted:
           email_intro: Your account has been deleted.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -4,7 +4,7 @@ fr:
       users:
         user_marked_for_auto_deletion:
           email_intro: Votre compte sera supprimé le %{date}.
-          email_outro: Veuillez vous reconnecter pour empêcher la suppression automatique de votre compte - %{sign_in_url}.
+          email_outro: Veuillez vous reconnecter pour empêcher la suppression automatique de votre compte - <a href="%{sign_in_url}">S'identifier</a>.
           email_subject: Votre compte sera supprimé le %{date}.
         user_auto_deleted:
           email_intro: Votre compte a été supprimé.

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -4,7 +4,7 @@ nl:
       users:
         user_marked_for_auto_deletion:
           email_intro: Uw account wordt verwijderd op %{date}.
-          email_outro: Log opnieuw in om te voorkomen dat uw account automatisch wordt verwijderd - %{sign_in_url}.
+          email_outro: Log opnieuw in om te voorkomen dat uw account automatisch wordt verwijderd - <a href="%{sign_in_url}">Log in</a>.
           email_subject: Uw account wordt verwijderd op %{date}.
         user_auto_deleted:
           email_intro: Uw account is verwijderd.


### PR DESCRIPTION
Bugfixes:
- fix marked event email sending, add missing translation argument
- update email sending on user deletion (use `user.clone` and `deliver_now` as email is cleared on deletion)
- make sign in url a link in email
- add a spec test that job is actually sending emails
- move 'delete admin users' setting to the top, for more clearance (system panel)
- refactor usage of `settings` in job